### PR TITLE
Fix prototype pollution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,9 @@ export function objectMerge(target, ...sources) {
 
   if (isObject(target) && isObject(source)) {
     for (const key in source) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return target;
+      }
       if (isObject(source[key])) {
         if (!target[key]) {
           Object.assign(target, { [key]: {} });


### PR DESCRIPTION
Hi,
This package is vulnerable to prototype pollution.
POC
```javascript
var {objectMerge } = require("deep-merge-object")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
objectMerge(obj, payload);
console.log("After : " + {}.polluted);
```
OUTPUT
```
Before : undefined
After : Yes! Its Polluted
```
After fix prototype pollution can be avoided.
```
Before : undefined
After : undefined
```